### PR TITLE
Add support for ALIAS to ipplan hosts

### DIFF
--- a/enforcer/records.go
+++ b/enforcer/records.go
@@ -16,7 +16,7 @@ func (e *Enforcer) GetAllRecords() ([]*Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	static, err := e.GetStaticRecords()
+	static, err := e.GetStaticRecords(hosts)
 	if err != nil {
 		return nil, err
 	}

--- a/enforcer/static.go
+++ b/enforcer/static.go
@@ -8,7 +8,15 @@ import (
 )
 
 // GetStaticRecords returns records that are specified in static YAML file
-func (e *Enforcer) GetStaticRecords() ([]*Record, error) {
+func (e *Enforcer) GetStaticRecords(hostr []*Record) ([]*Record, error) {
+	m := make(map[string][]*Record)
+	for _, r := range hostr {
+		if d, e := m[r.Name]; e {
+			m[r.Name] = append(d, r)
+		} else {
+			m[r.Name] = []*Record{r}
+		}
+	}
 	var records []*Record
 	reader := yaml.NewDecoder(e.static)
 	for {
@@ -29,12 +37,30 @@ func (e *Enforcer) GetStaticRecords() ([]*Record, error) {
 				continue
 			}
 			for _, d := range record.Data {
-				records = append(records, &Record{
-					Name: record.Name,
-					TTL:  record.TTL,
-					Type: record.Type,
-					Data: []string{d},
-				})
+				if record.Type == "ALIAS" {
+					if dsts, e := m[d]; e {
+						for _, dst := range dsts {
+							for _, ds := range dst.Data {
+								records = append(records, &Record{
+									Name: record.Name,
+									TTL:  record.TTL,
+									Type: dst.Type,
+									Data: []string{ds},
+								})
+							}
+						}
+						log.Infof("Added ALIAS %s for %s", record.Name, d)
+					} else {
+						log.Warningf("Found ALIAS %s pointing to non existing host %s", record.Name, d)
+					}
+				} else {
+					records = append(records, &Record{
+						Name: record.Name,
+						TTL:  record.TTL,
+						Type: record.Type,
+						Data: []string{d},
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
```
~/Projects/src/github.com/dhtech/dnsenforcer [support-aliases] $ go run cmd/enforce/main.go --dry-run
INFO[0000] Generating DNS records...
WARN[0001] dhtech.vl501.v4.dc1.as59835.net. is not a member of any of the enforced zones
WARN[0001] dhtech.vl502.v4.dc1.as59835.net. is not a member of any of the enforced zones
WARN[0001] bokning.dreamhack.se. is not a member of any of the enforced zones
WARN[0001] Found ignored type NS for net.dreamhack.se. in static file
WARN[0001] Found ignored type NS for 7.3.3.1.0.0.b.4.2.0.a.2.ip6.arpa. in static file
WARN[0001] Found ignored type NS for 2.4.2.2.5.0.a.2.ip6.arpa. in static file
WARN[0001] Found ignored type NS for tech.dreamhack.se. in static file
WARN[0001] Found ignored type NS for 0.4.2.2.5.0.a.2.ip6.arpa. in static file
WARN[0001] Found ignored type NS for event.dreamhack.se. in static file
INFO[0001] Added ALIAS jumpgate.event.dreamhack.se. for jumpgate1.event.dreamhack.se.
INFO[0001] Added ALIAS jumpgate.event.dreamhack.se. for jumpgate2.event.dreamhack.se.
-logistics.tech.dreamhack.se.:CNAME:0:assets.tech.dreamhack.se.
-_acme-challenge.playground.tech.dreamhack.se.:TXT:0:"GwHTxt1CcfewQH_cZTq3SpjXpBws2_KwyZOl7w572kw"
+logistics.tech.dreamhack.se.:CNAME:1337:assets.tech.dreamhack.se
+jumpgate.event.dreamhack.se.:A:1337:77.80.228.16
+jumpgate.event.dreamhack.se.:AAAA:1337:2a05:2242:910::16
+jumpgate.event.dreamhack.se.:A:1337:77.80.228.70
+jumpgate.event.dreamhack.se.:AAAA:1337:2a05:2242:911::70
INFO[0001] Records updated
```